### PR TITLE
fix: 🐛 enable adding string values to the fields

### DIFF
--- a/src/commands/FSet.test.ts
+++ b/src/commands/FSet.test.ts
@@ -30,5 +30,9 @@ describe('FSet', () => {
             'FSET',
             [key, id, 'height', 20],
         ]);
+        expect(query.fields({ city: 'Berlin' }).compile()).toEqual([
+            'FSET',
+            [key, id, 'city', 'Berlin'],
+        ]);
     });
 });

--- a/src/commands/Set.test.ts
+++ b/src/commands/Set.test.ts
@@ -16,6 +16,16 @@ describe('Set', () => {
             'SET',
             [key, id, 'FIELD', 'speed', 10, 'FIELD', 'weight', 100],
         ]);
+        expect(
+            query.fields({ city: 'Berlin', country: 'Germany' }).compile()
+        ).toEqual([
+            'SET',
+            [key, id, 'FIELD', 'city', 'Berlin', 'FIELD', 'country', 'Germany'],
+        ]);
+        expect(query.fields({ city: 'Berlin', speed: 100 }).compile()).toEqual([
+            'SET',
+            [key, id, 'FIELD', 'city', 'Berlin', 'FIELD', 'speed', 100],
+        ]);
         expect(query.fields({ speed: 1 }).compile()).toEqual([
             'SET',
             [key, id, 'FIELD', 'speed', 1],

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -11,7 +11,7 @@ export interface Bounds {
     sw: LatLon;
 }
 
-export type Fields = Record<string, number>;
+export type Fields = Record<string, number | string>;
 
 export type Meta = Record<string, string>;
 


### PR DESCRIPTION
As of Tile38 1.30.0, Fields is no longer limited to numbers.
https://tile38.com/commands/set

 This is to enable string values in the fields. 

Change log:
1. enabled string in Field
2. added tests to verify